### PR TITLE
Adding string_view in header to compile with clang

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 CMakeLists.txt.user
+build/

--- a/include/strn/hash.hpp
+++ b/include/strn/hash.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <string_view>
 #include <functional>
 #include <cstdint>
 #include <cstdlib>


### PR DESCRIPTION
The compilation does not work well on my mac : 

```
❯ cmake ..
-- The CXX compiler identification is AppleClang 11.0.0.11000033
-- Check for working CXX compiler: /Library/Developer/CommandLineTools/usr/bin/c++
-- Check for working CXX compiler: /Library/Developer/CommandLineTools/usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Setting build type to 'Release' as none was specified.
-- CMAKE_CXX_COMPILER: /Library/Developer/CommandLineTools/usr/bin/c++
-- CMAKE_BUILD_TYPE: Release
-- CMAKE_CXX_FLAGS:
-- CMAKE_CXX_FLAGS_DEBUG: -g
-- CMAKE_CXX_FLAGS_RELEASE: -O3 -DNDEBUG
-- Configuring done
-- Generating done
-- Build files have been written to: /Users/sylvestre/codes/strn/build
```
```
❯ cmake --build .
[ 33%] Building CXX object CMakeFiles/strn.dir/src/string64.cpp.o
In file included from /Users/sylvestre/codes/strn/src/string64.cpp:1:
In file included from /Users/sylvestre/codes/strn/include/strn/string64.hpp:4:
/Users/sylvestre/codes/strn/include/strn/hash.hpp:24:27: error: no member named 'string_view' in namespace 'std'
    return std::hash<std::string_view>{}(cstr);
                     ~~~~~^
1 error generated.
make[2]: *** [CMakeFiles/strn.dir/src/string64.cpp.o] Error 1
make[1]: *** [CMakeFiles/strn.dir/all] Error 2
make: *** [all] Error 2
```

Just add the header of string view solve the issue.

```
❯ cmake --build .
Scanning dependencies of target strn
[ 33%] Building CXX object CMakeFiles/strn.dir/src/io.cpp.o
[ 66%] Building CXX object CMakeFiles/strn.dir/src/string64.cpp.o
[100%] Linking CXX shared library Release/lib/libstrn.dylib
[100%] Built target strn
```